### PR TITLE
FIX: mensaje corregido en método guia1.ej03.CuentaBancaria.extraer()

### DIFF
--- a/src/resueltos/guia1/ej03/CuentaBancaria.java
+++ b/src/resueltos/guia1/ej03/CuentaBancaria.java
@@ -39,7 +39,7 @@ public class CuentaBancaria {
                 System.out.println("Su saldo disponible no permite extraer ARS "+ monto);
             }
         } else{
-            System.out.println("El monto a depositar debe ser un real positivo");
+            System.out.println("El monto a extraer debe ser un real positivo");
         }
         
         


### PR DESCRIPTION
Reenvio el fix originalmente propuesto en el PR anterior (#1), que fue cerrado para reorganizar las ramas del fork y mantener la sincronización con el repositorio oficial.

Este fix corrige el texto impreso por el método `guia1.ej03.CuentaBancaria.extraer()` cuando el monto no es positivo.
El mensaje anterior imprimía `"depositar"` cuando debía ser `"extraer"`.